### PR TITLE
feat: improve data imports and add FireRed theme

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,9 @@ export default function App() {
 
   return (
     <div className="min-h-screen">
-      <header className="p-4 text-center text-2xl">Nuzlocke Generalizer v1.0</header>
+      <header className="p-4 text-center text-2xl bg-red-900 text-yellow-100 border-b-4 border-yellow-500">
+        Nuzlocke Generalizer v1.0
+      </header>
       <ImportPanel
         setTeam={setTeam}
         setPc={setPc}

--- a/client/src/components/ImportPanel.tsx
+++ b/client/src/components/ImportPanel.tsx
@@ -11,7 +11,13 @@ interface Props {
   addLog: (m: string) => void;
 }
 
-export default function ImportPanel({ setTeam, setPc, setTrainers, log, addLog }: Props) {
+export default function ImportPanel({
+  setTeam,
+  setPc,
+  setTrainers,
+  log,
+  addLog,
+}: Props) {
   const showdownRef = useRef<HTMLInputElement>(null);
   const rxdataRef = useRef<HTMLInputElement>(null);
   const trainersRef = useRef<HTMLTextAreaElement>(null);
@@ -54,27 +60,35 @@ export default function ImportPanel({ setTeam, setPc, setTrainers, log, addLog }
   };
 
   return (
-    <div className="p-4 space-y-4 border-2 border-white bg-gray-900">
+    <div className="p-4 space-y-4 border-2 border-yellow-500 bg-red-900 text-yellow-200">
       <h2 className="text-xl mb-2">Import</h2>
       <div>
         <input ref={showdownRef} type="file" accept=".txt" />
-        <button className="ml-2 px-2 py-1 bg-yellow-400 text-black" onClick={handleShowdown}>
+        <button className="ml-2" onClick={handleShowdown}>
           Load
         </button>
       </div>
       <div>
         <input ref={rxdataRef} type="file" accept=".rxdata" />
-        <button className="ml-2 px-2 py-1 bg-yellow-400 text-black" onClick={handleRxdata}>
+        <button className="ml-2" onClick={handleRxdata}>
           Load
         </button>
       </div>
       <div>
-        <textarea ref={trainersRef} className="w-full h-24 text-black" placeholder="Trainers JSON" />
-        <button className="mt-1 px-2 py-1 bg-yellow-400 text-black" onClick={handleTrainers}>
+        <textarea
+          ref={trainersRef}
+          className="w-full h-24 text-black"
+          placeholder="Trainers JSON"
+        />
+        <button className="mt-1" onClick={handleTrainers}>
           Load Trainers
         </button>
       </div>
-      <textarea className="w-full h-24 text-black" readOnly value={log.join('\n')} />
+      <textarea
+        className="w-full h-24 text-black"
+        readOnly
+        value={log.join('\n')}
+      />
     </div>
   );
 }

--- a/client/src/components/PcGrid.tsx
+++ b/client/src/components/PcGrid.tsx
@@ -20,11 +20,20 @@ export default function PcGrid({ pc }: { pc: PcMon[] }) {
 
   return (
     <div className="p-4">
-      <h2 className="text-xl mb-2">PC</h2>
+      <h2 className="text-xl mb-2 text-yellow-100">PC</h2>
       <div className="grid grid-cols-6 gap-2 max-h-64 overflow-y-auto">
         {pc.map((m, i) => (
-          <div key={i} className="border-2 border-white p-1 bg-gray-800 text-xs text-center">
-            {m.sprite && <img src={m.sprite} alt={m.species} className="w-12 h-12 mx-auto" />}
+          <div
+            key={i}
+            className="border-2 border-yellow-500 p-1 bg-red-900 text-xs text-center"
+          >
+            {m.sprite && (
+              <img
+                src={m.sprite}
+                alt={m.species}
+                className="w-12 h-12 mx-auto"
+              />
+            )}
             <div>{m.nick || m.species}</div>
             <div className="flex justify-center gap-1 mt-1">
               {m.types.map((t) => (

--- a/client/src/components/TeamView.tsx
+++ b/client/src/components/TeamView.tsx
@@ -20,18 +20,29 @@ export default function TeamView({ team }: { team: TeamMon[] }) {
 
   return (
     <div className="p-4">
-      <h2 className="text-xl mb-2">Team</h2>
+      <h2 className="text-xl mb-2 text-yellow-100">Team</h2>
       <div className="grid grid-cols-3 gap-2">
         {team.map((m, i) => (
-          <div key={i} className="border-2 border-white p-2 bg-gray-800 text-center">
-            {m.sprite && <img src={m.sprite} alt={m.species} className="w-16 h-16 mx-auto" />}
+          <div
+            key={i}
+            className="border-2 border-yellow-500 p-2 bg-red-900 text-center"
+          >
+            {m.sprite && (
+              <img
+                src={m.sprite}
+                alt={m.species}
+                className="w-16 h-16 mx-auto"
+              />
+            )}
             <div className="text-sm mt-1">{m.nick || m.species}</div>
             <div className="flex justify-center gap-1 text-xs mt-1">
               {m.types.map((t) => (
                 <TypeBadge key={t} type={t} />
               ))}
             </div>
-            {m.ability && <div className="text-xs mt-1">Ability: {m.ability}</div>}
+            {m.ability && (
+              <div className="text-xs mt-1">Ability: {m.ability}</div>
+            )}
             {m.item && <div className="text-xs">Item: {m.item}</div>}
             <ul className="text-xs list-disc ml-4 text-left">
               {m.moves.map((mv, j) => (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  background-color: #8b0000;
+  color: #fffae6;
+  font-family: 'Press Start 2P', monospace;
+}
+
+button {
+  border: 2px solid #ffcc00;
+  background-color: #ffcc00;
+  color: #000;
+  padding: 0.25rem 0.5rem;
+}

--- a/client/src/lib/rxdata.ts
+++ b/client/src/lib/rxdata.ts
@@ -46,17 +46,30 @@ export function decodeMarshal(buf: Uint8Array): AnyObj {
         return false;
       case 'i':
         return readInt(buf, offsetObj);
+      case 'l': {
+        const sign = String.fromCharCode(buf[offsetObj.offset++]);
+        const len = readInt(buf, offsetObj) * 2;
+        let n = 0n;
+        for (let i = 0; i < len; i++) {
+          n += BigInt(buf[offsetObj.offset++]) << BigInt(8 * i);
+        }
+        const num = sign === '-' ? -n : n;
+        const asNum = Number(num);
+        return Number.isSafeInteger(asNum) ? asNum : num;
+      }
       case 'f': {
         const len = readInt(buf, offsetObj);
         const str = textDecoder.decode(
-          buf.slice(offsetObj.offset, offsetObj.offset + len)
+          buf.slice(offsetObj.offset, offsetObj.offset + len),
         );
         offsetObj.offset += len;
         return parseFloat(str);
       }
       case ':': {
         const len = readInt(buf, offsetObj);
-        const str = textDecoder.decode(buf.slice(offsetObj.offset, offsetObj.offset + len));
+        const str = textDecoder.decode(
+          buf.slice(offsetObj.offset, offsetObj.offset + len),
+        );
         offsetObj.offset += len;
         symbols.push(str);
         return str;
@@ -67,7 +80,9 @@ export function decodeMarshal(buf: Uint8Array): AnyObj {
       }
       case '"': {
         const len = readInt(buf, offsetObj);
-        const str = textDecoder.decode(buf.slice(offsetObj.offset, offsetObj.offset + len));
+        const str = textDecoder.decode(
+          buf.slice(offsetObj.offset, offsetObj.offset + len),
+        );
         offsetObj.offset += len;
         objects.push(str);
         return str;
@@ -111,4 +126,60 @@ export function decodeMarshal(buf: Uint8Array): AnyObj {
         const len = readInt(buf, offsetObj);
         for (let i = 0; i < len; i++) {
           read();
-          read
+          read();
+        }
+        return inner;
+      }
+      default:
+        throw new Error('Unknown tag ' + tag);
+    }
+  };
+
+  // header
+  offsetObj.offset += 2; // major, minor
+  return read();
+}
+
+const normalize = (s: string | number) =>
+  typeof s === 'number'
+    ? String(s)
+    : s
+        .toString()
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9-]/g, '-')
+        .replace(/-+/g, '-');
+
+function parseRxdata(buf: ArrayBuffer): PcMon[] {
+  const root = decodeMarshal(new Uint8Array(buf));
+  const result: PcMon[] = [];
+  const queue: any[] = [root];
+  const seen = new Set<any>();
+  while (queue.length) {
+    const node = queue.shift();
+    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+    seen.add(node);
+    const species = node['@species'] ?? node.species ?? node.Species;
+    if (species !== undefined) {
+      const nick = node['@name'] ?? node.name ?? node.nickname;
+      const ability = node['@ability'] ?? node.ability;
+      const item = node['@item'] ?? node.item;
+      result.push({
+        nick,
+        species: normalize(species),
+        types: [],
+        ability,
+        item,
+      });
+    }
+    for (const key in node) {
+      queue.push(node[key]);
+    }
+    if (Array.isArray(node)) {
+      for (const val of node) queue.push(val);
+    }
+  }
+  return result;
+}
+
+export { parseRxdata };

--- a/client/src/lib/showdown.ts
+++ b/client/src/lib/showdown.ts
@@ -8,10 +8,7 @@ const normalize = (s: string) =>
     .replace(/-+/g, '-');
 
 export function parseShowdown(text: string): TeamMon[] {
-  const blocks = text
-    .replace(/\r/g, '')
-    .trim()
-    .split(/\n\n+/);
+  const blocks = text.replace(/\r/g, '').trim().split(/\n\n+/);
 
   const team: TeamMon[] = [];
   for (const block of blocks) {
@@ -26,7 +23,9 @@ export function parseShowdown(text: string): TeamMon[] {
 
     const first = lines[0];
     const mon: TeamMon = { species: '', moves: [], types: [] };
-    const m = first.match(/^(.*?)(?: \(([^\)]+)\))?(?: @ (.*))?$/);
+    const m = first.match(
+      /^(.*?)(?: \(([^\)]+)\))?(?: \((?:M|F)\))?(?: @ (.*))?$/,
+    );
 
     if (m) {
       if (m[2]) {


### PR DESCRIPTION
## Summary
- handle Ruby bignums and `@`-prefixed fields in rxdata decoder
- ignore gender markers in Showdown imports to fetch correct Pokémon data
- apply FireRed-inspired red/yellow pixel theme across the interface

## Testing
- `CI=true npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf69c55650832295f03e61aff68c6c