### PR TITLE
Fix pdf.js worker import path

### DIFF
--- a/client/src/lib/trainerPdf.ts
+++ b/client/src/lib/trainerPdf.ts
@@ -1,6 +1,7 @@
 import type { Trainer } from '../models';
-import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
-import workerSrc from 'pdfjs-dist/legacy/build/pdf.worker.min.js?url';
+// Use the modern ESM build of pdf.js and explicitly point to the worker.
+import * as pdfjsLib from 'pdfjs-dist';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
 
 (pdfjsLib as any).GlobalWorkerOptions.workerSrc = workerSrc;


### PR DESCRIPTION
## Summary
- update pdf.js import to use ESM build and explicit worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf8edf4de48322b69d794bc302f735