### PR TITLE
Fix trainer PDF parsing and load full PC

### DIFF
--- a/client/src/lib/rxdata.ts
+++ b/client/src/lib/rxdata.ts
@@ -153,11 +153,10 @@ const normalize = (s: string | number) =>
 function parseRxdata(buf: ArrayBuffer): PcMon[] {
   const root = decodeMarshal(new Uint8Array(buf));
   const result: PcMon[] = [];
-  const queue: any[] = [root];
   const seen = new Set<any>();
-  while (queue.length) {
-    const node = queue.shift();
-    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+
+  const walk = (node: any) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
     seen.add(node);
     const species = node['@species'] ?? node.species ?? node.Species;
     if (species !== undefined) {
@@ -172,13 +171,11 @@ function parseRxdata(buf: ArrayBuffer): PcMon[] {
         item,
       });
     }
-    for (const key in node) {
-      queue.push(node[key]);
-    }
-    if (Array.isArray(node)) {
-      for (const val of node) queue.push(val);
-    }
-  }
+    if (Array.isArray(node)) node.forEach(walk);
+    else for (const key in node) walk(node[key]);
+  };
+
+  walk(root);
   return result;
 }
 

--- a/client/src/lib/trainerPdf.ts
+++ b/client/src/lib/trainerPdf.ts
@@ -1,6 +1,7 @@
 import type { Trainer } from '../models';
-import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
-import workerSrc from 'pdfjs-dist/legacy/build/pdf.worker.min.js?url';
+// Use the modern ESM build of pdf.js and explicitly point to the worker.
+import * as pdfjsLib from 'pdfjs-dist';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
 
 (pdfjsLib as any).GlobalWorkerOptions.workerSrc = workerSrc;
@@ -17,10 +18,10 @@ export async function parseTrainerPdf(data: ArrayBuffer): Promise<Trainer[]> {
   for (let i = 1; i <= pdf.numPages; i++) {
     const page = await pdf.getPage(i);
     const content = await page.getTextContent();
-    raw +=
-      content.items
-        .map((it: any) => ('str' in it ? it.str : ''))
-        .join(' ') + '\n';
+    for (const it of content.items as any[]) {
+      if ('str' in it) raw += it.str;
+      raw += it.hasEOL ? '\n' : ' ';
+    }
   }
   const lines = raw
     .split(/\n+/)


### PR DESCRIPTION
## Summary
- preserve line breaks when parsing trainer PDFs so rosters and moves render properly
- traverse entire rxdata object graph to collect party and PC Pokemon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf8edf4de48322b69d794bc302f735