### PR TITLE
Fix trainer PDF parsing and load full PC

### DIFF
--- a/client/src/components/Guide.tsx
+++ b/client/src/components/Guide.tsx
@@ -3,6 +3,13 @@ import { Trainer, TeamMon, PcMon } from '../models';
 import { getPokemon, getMove, getMultiplier } from '../lib/pokeapi';
 import { TypeBadge } from './TypeBadge';
 
+const normalize = (s: string) =>
+  s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-');
+
 interface Props {
   trainers: Trainer[];
   team: TeamMon[];
@@ -21,7 +28,7 @@ export default function Guide({ trainers, team, pc }: Props) {
         for (const moves of tr.moves) {
           for (const mv of moves) {
             try {
-              const { type } = await getMove(mv);
+              const { type } = await getMove(normalize(mv));
               team.forEach((mon) => {
                 const mult = getMultiplier(type, mon.types);
                 if (mult >= 2) set.add(type);
@@ -169,7 +176,7 @@ function TrainerRow({
 function MoveCell({ move }: { move: string }) {
   const [type, setType] = useState('');
   useEffect(() => {
-    getMove(move)
+    getMove(normalize(move))
       .then((m) => setType(m.type))
       .catch(() => setType('?'));
   }, [move]);
@@ -183,7 +190,7 @@ function MoveCell({ move }: { move: string }) {
 function ThreatCell({ move, team }: { move: string; team: TeamMon[] }) {
   const [type, setType] = useState('');
   useEffect(() => {
-    getMove(move)
+    getMove(normalize(move))
       .then((m) => setType(m.type))
       .catch(() => setType(''));
   }, [move]);

--- a/client/src/lib/rxdata.ts
+++ b/client/src/lib/rxdata.ts
@@ -30,8 +30,10 @@ function readInt(buf: Uint8Array, offsetObj: { offset: number }): number {
   return 0;
 }
 
-export function decodeMarshal(buf: Uint8Array): AnyObj {
-  const offsetObj = { offset: 0 };
+export function decodeMarshal(
+  buf: Uint8Array,
+  offsetObj: { offset: number } = { offset: 0 },
+): AnyObj {
   const objects: any[] = [];
   const symbols: string[] = [];
 
@@ -130,6 +132,15 @@ export function decodeMarshal(buf: Uint8Array): AnyObj {
         }
         return inner;
       }
+      case 'u': {
+        const klass = read();
+        const len = readInt(buf, offsetObj);
+        const raw = buf.slice(offsetObj.offset, offsetObj.offset + len);
+        offsetObj.offset += len;
+        const obj: any = { __class__: klass, __raw__: raw };
+        objects.push(obj);
+        return obj;
+      }
       default:
         throw new Error('Unknown tag ' + tag);
     }
@@ -151,14 +162,31 @@ const normalize = (s: string | number) =>
         .replace(/-+/g, '-');
 
 function parseRxdata(buf: ArrayBuffer): PcMon[] {
-  const root = decodeMarshal(new Uint8Array(buf));
+  const bytes = new Uint8Array(buf);
+  const offset = { offset: 0 };
+  const roots: AnyObj[] = [];
+  while (offset.offset < bytes.length) {
+    try {
+      roots.push(decodeMarshal(bytes, offset));
+    } catch {
+      break;
+    }
+  }
+
   const result: PcMon[] = [];
-  const queue: any[] = [root];
   const seen = new Set<any>();
-  while (queue.length) {
-    const node = queue.shift();
-    if (!node || typeof node !== 'object' || seen.has(node)) continue;
+
+  const walk = (node: any) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return;
     seen.add(node);
+    if (node.__raw__ instanceof Uint8Array) {
+      try {
+        const inner = decodeMarshal(node.__raw__);
+        walk(inner);
+      } catch {
+        // ignore decode errors
+      }
+    }
     const species = node['@species'] ?? node.species ?? node.Species;
     if (species !== undefined) {
       const nick = node['@name'] ?? node.name ?? node.nickname;
@@ -172,13 +200,11 @@ function parseRxdata(buf: ArrayBuffer): PcMon[] {
         item,
       });
     }
-    for (const key in node) {
-      queue.push(node[key]);
-    }
-    if (Array.isArray(node)) {
-      for (const val of node) queue.push(val);
-    }
-  }
+    if (Array.isArray(node)) node.forEach(walk);
+    else for (const key in node) walk(node[key]);
+  };
+
+  roots.forEach(walk);
   return result;
 }
 

--- a/client/src/lib/trainerPdf.ts
+++ b/client/src/lib/trainerPdf.ts
@@ -1,7 +1,7 @@
 import type { Trainer } from '../models';
-import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
-import workerSrc from 'pdfjs-dist/legacy/build/pdf.worker.min.js?url';
-
+// Use the modern ESM build of pdf.js and explicitly point to the worker.
+import * as pdfjsLib from 'pdfjs-dist';
+import workerSrc from 'pdfjs-dist/build/pdf.worker.min.mjs?url';
 
 (pdfjsLib as any).GlobalWorkerOptions.workerSrc = workerSrc;
 
@@ -13,42 +13,87 @@ const normalize = (s: string) =>
 
 export async function parseTrainerPdf(data: ArrayBuffer): Promise<Trainer[]> {
   const pdf = await pdfjsLib.getDocument({ data }).promise;
-  let raw = '';
+  // capture each text item along with its X coordinate so we can drop
+  // left-margin notes that aren't part of the roster tables
+  const rows: { str: string; x: number }[][] = [];
   for (let i = 1; i <= pdf.numPages; i++) {
     const page = await pdf.getPage(i);
     const content = await page.getTextContent();
-    raw +=
-      content.items
-        .map((it: any) => ('str' in it ? it.str : ''))
-        .join(' ') + '\n';
+    const items = (content.items as any[])
+      .filter((it) => 'str' in it && it.str.trim())
+      .map((it) => ({ str: it.str.trim(), x: it.transform[4], y: it.transform[5] }))
+      .sort((a, b) => (Math.abs(a.y - b.y) < 2 ? a.x - b.x : b.y - a.y));
+    let lineY: number | null = null;
+    let line: { str: string; x: number }[] = [];
+    for (const it of items) {
+      if (lineY === null || Math.abs(it.y - lineY) > 2) {
+        if (line.length) rows.push(line);
+        line = [it];
+        lineY = it.y;
+      } else {
+        line.push(it);
+      }
+    }
+    if (line.length) rows.push(line);
   }
-  const lines = raw
-    .split(/\n+/)
-    .map((l) => l.trim())
-    .filter((l) => l);
+
   const trainers: Trainer[] = [];
   let current: { title: string; roster: string[]; moves: string[][] } | null =
     null;
-  for (const line of lines) {
-    if (/^(Rival|L[ií]der|Alto|Campe[oó]n)/i.test(line)) {
+  // Track the current block of Pokémon to correctly associate move rows.
+  let blockStart = 0;
+  let blockCols = 0;
+  let blockMoves = 0;
+  let skip = 0;
+  const MIN_COL_X = 150; // left edge of roster tables
+  for (const raw of rows) {
+    const cells = raw.filter((c) => c.x >= MIN_COL_X).map((c) => c.str);
+    const first = cells[0] ?? '';
+
+    if (/^(Rival|L[ií]der|Alto|Campe[oó]n)/i.test(first)) {
       if (current) trainers.push({ ...current });
-      current = { title: line, roster: [], moves: [] };
+      current = { title: first, roster: [], moves: [] };
+      blockStart = 0;
+      blockCols = 0;
+      blockMoves = 0;
+      skip = 0;
       continue;
     }
     if (!current) continue;
-    if (!current.roster.length && /^[A-ZÁÉÍÓÚÜÑ0-9\s-]+$/.test(line)) {
-      const mons = line.split(/\s+/).filter(Boolean).map(normalize);
-      current.roster = mons;
-      current.moves = mons.map(() => []);
+
+    if (skip > 0) {
+      skip--;
       continue;
     }
-    if (current.roster.length && !/:/.test(line) && /^[A-ZÁÉÍÓÚÜÑ0-9\s-]+$/.test(line)) {
-      const tokens = line.split(/\s+/);
-      for (let i = 0; i < current.roster.length; i++) {
-        const mv = tokens[i];
-        if (mv && mv !== '---') current.moves[i].push(normalize(mv));
-      }
+
+    const isRoster =
+      cells.length > 0 && cells.every((c) => /^[A-ZÁÉÍÓÚÜÑ0-9\s-]+$/.test(c));
+    if (isRoster) {
+      // Start a new roster block (handles multiple possible parties).
+      blockStart = current.roster.length;
+      blockCols = cells.length;
+      blockMoves = 0;
+      current.roster.push(...cells.map(normalize));
+      for (let i = 0; i < cells.length; i++) current.moves.push([]);
+      // Skip the immediate type row that follows the roster names.
+      skip = 1;
+      continue;
     }
+
+    if (cells.some((c) => c.includes(':'))) continue;
+    if (!cells.some((c) => c.trim())) continue;
+    if (blockCols === 0) continue;
+
+    const valid = cells.slice(0, blockCols).filter((c) => c && c !== '---');
+    if (valid.length === 0 || (blockCols > 1 && valid.length === 1 && blockMoves)) {
+      blockCols = 0;
+      continue;
+    }
+    for (let i = 0; i < blockCols; i++) {
+      const mv = cells[i];
+      if (mv && mv !== '---') current.moves[blockStart + i].push(mv);
+    }
+    blockMoves++;
   }
   if (current) trainers.push(current);
   return trainers;

--- a/client/src/types/pdfjs-worker.d.ts
+++ b/client/src/types/pdfjs-worker.d.ts
@@ -1,0 +1,4 @@
+declare module 'pdfjs-dist/build/pdf.worker.min.mjs?url' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- read x coordinates from trainer PDF to ignore margin text and capture roster grids reliably
- recurse into marshal blobs when loading rxdata so party and PC Pokémon are included

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf8edf4de48322b69d794bc302f735