### PR TITLE
fix: update pdfjs worker path

### DIFF
--- a/client/src/lib/trainerPdf.ts
+++ b/client/src/lib/trainerPdf.ts
@@ -92,11 +92,17 @@ async function readPdfTextItems(data: ArrayBuffer | Uint8Array) {
   try {
     // Works if consumer installed `pdfjs-dist`
     pdfjs = await import(/* @vite-ignore */ "pdfjs-dist/build/pdf");
-    // Worker is optional if bundler inlines it; suppress if not found
+    // Worker is optional if bundler inlines it; pdfjs-dist 5+ uses an .mjs worker file
     try {
-      const workerSrc = (await import(/* @vite-ignore */ "pdfjs-dist/build/pdf.worker.js?url")).default;
+      const workerSrc = (
+        await import(
+          /* @vite-ignore */ "pdfjs-dist/build/pdf.worker.min.mjs?url"
+        )
+      ).default;
       if (pdfjs.GlobalWorkerOptions) pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore if worker not found */
+    }
   } catch (e) {
     throw new Error("pdfjs-dist not found. Install it or use parseText() fallback.");
   }
@@ -330,6 +336,14 @@ export async function parsePdf(data: ArrayBuffer | Uint8Array): Promise<ParseRes
   const res = assembleResult(blocks);
   (res as any).debug = { pages: pages.length, lines: allLines.length, blocks: blocks.length };
   return res;
+}
+
+// Legacy wrapper retained for existing imports that expect an array.
+export async function parseTrainerPdf(
+  data: ArrayBuffer | Uint8Array,
+): Promise<Trainer[]> {
+  const res = await parsePdf(data);
+  return res.trainers;
 }
 
 // Fallback parser: accepts plain text extracted elsewhere (no geometry), best-effort.


### PR DESCRIPTION
## Summary
- update pdfjs worker import to new `.mjs` path
- expose legacy `parseTrainerPdf` alias
- keep `parseTrainerPdf` return type as `Trainer[]`

## Testing
- `npx vitest run`
- `npm run --workspace client build`


------
https://chatgpt.com/codex/tasks/task_e_68c03b9fd8908322bafa40fef6f0429c