### PR TITLE
feat: add trainer pdf parser

### DIFF
--- a/client/test/trainerPdf.test.ts
+++ b/client/test/trainerPdf.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { parseTrainerText } from '../src/lib/trainerPdf';
+
+describe('parseTrainerText', () => {
+  it('parses trainer block into roster and moves', () => {
+    const text = `Lider\nPikachu - Thunderbolt, Quick Attack\nCharmander - Flamethrower`;
+    const trainers = parseTrainerText(text);
+    expect(trainers).toHaveLength(1);
+    expect(trainers[0]).toEqual({
+      title: 'Lider',
+      double: false,
+      roster: ['pikachu', 'charmander'],
+      moves: [
+        ['Thunderbolt', 'Quick Attack'],
+        ['Flamethrower'],
+      ],
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- parse trainer guides from PDF or plain text
- add unit tests for trainer parsing

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c059c1b3008322974ec612c6e9f6c8