### PR TITLE
Add species override and retro-style trainer tips

### DIFF
--- a/client/src/components/Guide.tsx
+++ b/client/src/components/Guide.tsx
@@ -71,6 +71,11 @@ export default function Guide({ trainers, team, pc }: Props) {
           >
             <div>
               {tr.title} {tr.double && <span className="text-xs">Doble</span>}
+              {tr.starting !== undefined && (
+                <div className="text-xs mt-1">
+                  Empieza con {String(tr.roster[tr.starting])}
+                </div>
+              )}
             </div>
             <div>{open === idx ? '-' : '+'}</div>
           </div>
@@ -82,6 +87,7 @@ export default function Guide({ trainers, team, pc }: Props) {
                   <th>Tipos</th>
                   <th>Movimientos</th>
                   <th>Amenazas</th>
+                  <th>Consejos</th>
                 </tr>
               </thead>
               <tbody>
@@ -91,6 +97,7 @@ export default function Guide({ trainers, team, pc }: Props) {
                     species={sp}
                     moves={tr.moves[i]}
                     team={team}
+                    tip={tr.tips?.[i]}
                   />
                 ))}
               </tbody>
@@ -118,10 +125,12 @@ function TrainerRow({
   species,
   moves,
   team,
+  tip,
 }: {
   species: string | number;
   moves: number[];
   team: TeamMon[];
+  tip?: string[];
 }) {
   const [types, setTypes] = useState<string[]>([]);
   const [sprite, setSprite] = useState<string>('');
@@ -162,6 +171,13 @@ function TrainerRow({
         <ul>
           {moves.map((mv, idx) => (
             <ThreatCell key={idx} move={mv} team={team} />
+          ))}
+        </ul>
+      </td>
+      <td>
+        <ul>
+          {tip?.map((t, i) => (
+            <li key={i}>{t}</li>
           ))}
         </ul>
       </td>

--- a/client/src/components/PcGrid.tsx
+++ b/client/src/components/PcGrid.tsx
@@ -103,6 +103,26 @@ export default function PcGrid({
             <button
               className="mt-1 border border-yellow-500 px-1"
               onClick={() => {
+                const sp = prompt('Nueva especie', m.species);
+                if (sp) {
+                  const updated = {
+                    ...m,
+                    species: sp,
+                    speciesName: undefined,
+                    sprite: undefined,
+                    types: [],
+                  };
+                  const newPc = [...pc];
+                  newPc[i] = updated;
+                  setPc(newPc);
+                }
+              }}
+            >
+              Corregir
+            </button>
+            <button
+              className="mt-1 border border-yellow-500 px-1"
+              onClick={() => {
                 if (team.length >= 6) return;
                 const newPc = pc.filter((_, idx) => idx !== i);
                 setPc(newPc);

--- a/client/src/components/TeamView.tsx
+++ b/client/src/components/TeamView.tsx
@@ -111,6 +111,26 @@ export default function TeamView({
             >
               Al PC
             </button>
+            <button
+              className="mt-1 ml-1 text-xs border border-yellow-500 px-1"
+              onClick={() => {
+                const sp = prompt('Nueva especie', m.species);
+                if (sp) {
+                  const updated = {
+                    ...m,
+                    species: sp,
+                    speciesName: undefined,
+                    sprite: undefined,
+                    types: [],
+                  };
+                  const newTeam = [...team];
+                  newTeam[i] = updated;
+                  setTeam(newTeam);
+                }
+              }}
+            >
+              Corregir
+            </button>
           </div>
         ))}
       </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,16 @@
-@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  background-color: #8b0000;
+  background-color: #a8e0a8;
+  background-image:
+    linear-gradient(0deg, rgba(0, 0, 0, 0.1) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.1) 1px, transparent 1px);
+  background-size: 16px 16px;
+  image-rendering: pixelated;
   color: #fffae6;
-  font-family: 'Press Start 2P', monospace;
+  font-family: monospace;
 }
 
 button {
@@ -15,4 +18,8 @@ button {
   background-color: #ffcc00;
   color: #000;
   padding: 0.25rem 0.5rem;
+}
+
+img {
+  image-rendering: pixelated;
 }

--- a/client/src/lib/trainerPdf.ts
+++ b/client/src/lib/trainerPdf.ts
@@ -1,0 +1,3 @@
+export function normalizeText(str: string): string {
+  return str.replace(/\u0000/g, '').replace(/\s+/g, ' ').trim();
+}

--- a/client/src/models.ts
+++ b/client/src/models.ts
@@ -16,6 +16,8 @@ export type PcMon = TeamMon;
 export type Trainer = {
   title: string;
   double?: boolean;
+  starting?: number;
   roster: (string | number)[];
   moves: number[][];
+  tips?: string[][];
 };

--- a/data/trainers.json
+++ b/data/trainers.json
@@ -1,17 +1,26 @@
 [
   {
     "title": "Líder Brock",
+    "starting": 0,
     "roster": ["geodude", "onix"],
     "moves": [
       [33, 111, 88, 201],
       [88, 20, 106, 28]
+    ],
+    "tips": [
+      ["Usa movimientos de agua o planta"],
+      ["Movimientos de agua o planta son muy efectivos"]
     ]
   },
   {
     "title": "Joven Joey",
+    "starting": 0,
     "roster": ["rattata"],
     "moves": [
       [33, 39, 98, 158]
+    ],
+    "tips": [
+      ["Los movimientos de tipo lucha son supereficaces"]
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- allow manual correction of a Pokémon's species from team or PC views
- expand trainer data with starting Pokémon and per-mon battle tips
- restyle UI with CSS-based pixel grid background instead of binary tile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c217dba02483229fc77c1669ddc0dc