### PR TITLE
Avoid redundant state updates in team and PC views

### DIFF
--- a/client/src/components/PcGrid.tsx
+++ b/client/src/components/PcGrid.tsx
@@ -18,6 +18,7 @@ export default function PcGrid({
   useEffect(() => {
     let cancelled = false;
     const enrich = async () => {
+      let changed = false;
       await Promise.all(
         pc.map(async (m) => {
           if (!m.sprite || !m.types.length) {
@@ -25,6 +26,7 @@ export default function PcGrid({
               const data = await getPokemon(m.species);
               m.sprite = data.sprite;
               m.types = data.types;
+              changed = true;
             } catch {
               /* ignore */
             }
@@ -32,13 +34,19 @@ export default function PcGrid({
           if (m.ability && typeof m.ability === 'number') {
             try {
               const ab = await getAbility(m.ability);
-              if (ab) m.ability = ab;
+              if (ab) {
+                m.ability = ab;
+                changed = true;
+              }
             } catch {}
           }
           if (m.item && typeof m.item === 'number') {
             try {
               const it = await getItem(m.item);
-              if (it) m.item = it;
+              if (it) {
+                m.item = it;
+                changed = true;
+              }
             } catch {}
           }
           if (!m.moveNames || m.moveNames.length === 0) {
@@ -51,25 +59,29 @@ export default function PcGrid({
                 m.moveNames.push(String(id));
               }
             }
+            changed = true;
           }
           if (!m.speciesName) {
             const num = parseInt(m.species, 10);
             if (!isNaN(num)) {
               try {
                 const nm = await getPokemonName(num);
-                if (nm) m.speciesName = nm;
+                if (nm) {
+                  m.speciesName = nm;
+                  changed = true;
+                }
               } catch {}
             }
           }
         }),
       );
-      if (!cancelled) setPc([...pc]);
+      if (!cancelled && changed) setPc([...pc]);
     };
     enrich();
     return () => {
       cancelled = true;
     };
-  }, [pc, setPc]);
+  }, [pc]);
 
   return (
     <div className="p-4">

--- a/client/src/components/TeamView.tsx
+++ b/client/src/components/TeamView.tsx
@@ -16,6 +16,7 @@ export default function TeamView({
   useEffect(() => {
     let cancelled = false;
     const enrich = async () => {
+      let changed = false;
       await Promise.all(
         team.map(async (m) => {
           if (!m.sprite || !m.types.length) {
@@ -23,6 +24,7 @@ export default function TeamView({
               const data = await getPokemon(m.species);
               m.sprite = data.sprite;
               m.types = data.types;
+              changed = true;
             } catch {
               /* ignore */
             }
@@ -30,13 +32,19 @@ export default function TeamView({
           if (m.ability && typeof m.ability === 'number') {
             try {
               const ab = await getAbility(m.ability);
-              if (ab) m.ability = ab;
+              if (ab) {
+                m.ability = ab;
+                changed = true;
+              }
             } catch {}
           }
           if (m.item && typeof m.item === 'number') {
             try {
               const it = await getItem(m.item);
-              if (it) m.item = it;
+              if (it) {
+                m.item = it;
+                changed = true;
+              }
             } catch {}
           }
           if (!m.moveNames || m.moveNames.length === 0) {
@@ -49,25 +57,29 @@ export default function TeamView({
                 m.moveNames.push(String(id));
               }
             }
+            changed = true;
           }
           if (!m.speciesName) {
             const num = parseInt(m.species, 10);
             if (!isNaN(num)) {
               try {
                 const nm = await getPokemonName(num);
-                if (nm) m.speciesName = nm;
+                if (nm) {
+                  m.speciesName = nm;
+                  changed = true;
+                }
               } catch {}
             }
           }
         }),
       );
-      if (!cancelled) setTeam([...team]);
+      if (!cancelled && changed) setTeam([...team]);
     };
     enrich();
     return () => {
       cancelled = true;
     };
-  }, [team, setTeam]);
+  }, [team]);
 
   return (
     <div className="p-4">


### PR DESCRIPTION
## Summary
- Only update team state when enrichment modifies a Pokémon
- Do the same for PC state
- Depend effects on `team` or `pc` arrays only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2296694a88322b20d86f598d6714c